### PR TITLE
Add Permissions support

### DIFF
--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -49,12 +49,12 @@ class Intent():
     the API.AI develoepr console via JSON requests.
     """
 
-    def __init__(self, name=None, priority=500000, fallback_intent=False, intent_json=None):
+    def __init__(self, name=None, priority=500000, fallback_intent=False, contexts=None, intent_json=None):
 
         if name and not intent_json:
             self.name = name
             self.auto = True
-            self.contexts = []
+            self.contexts = contexts or []
             self.templates = []
             self.userSays = []
             self.responses = []

--- a/api_ai/schema_handlers.py
+++ b/api_ai/schema_handlers.py
@@ -121,7 +121,9 @@ class IntentGenerator(SchemaHandler):
     def build_intent(self, intent_name):
         """Builds an Intent object of the given name"""
         # TODO: contexts
-        new_intent = Intent(intent_name)
+        is_fallback = self.assist._intent_fallbacks[intent_name]
+        contexts = self.assist._required_contexts[intent_name]
+        new_intent = Intent(intent_name, fallback_intent=is_fallback, contexts=contexts)
         self.build_action(new_intent)
         self.build_user_says(new_intent)  # TODO
         return new_intent

--- a/flask_assistant/__init__.py
+++ b/flask_assistant/__init__.py
@@ -13,7 +13,7 @@ from flask_assistant.core import (
     request
 )
 
-from flask_assistant.response import ask, tell, event, build_item
+from flask_assistant.response import ask, tell, event, build_item, permission
 from flask_assistant.manager import Context
 
 from api_ai.api import ApiAi

--- a/flask_assistant/manager.py
+++ b/flask_assistant/manager.py
@@ -43,8 +43,10 @@ class ContextManager():
         self._cache[context.name] = context
         return context
 
-    def get(self, context_name):
-        return self._cache.get(context_name, Context(context_name))
+    def get(self, context_name, default=None):
+        if default is None:
+            default = Context(context_name)
+        return self._cache.get(context_name, default)
 
     def set(self, context_name, param, val):
         context = self.get(context_name)

--- a/flask_assistant/response.py
+++ b/flask_assistant/response.py
@@ -273,3 +273,23 @@ class event(_Response):
             "name": event_name,
             "data": kwargs
         }
+
+class permission(_Response):
+    """Returns a permission request to the user.
+
+    Arguments:
+        permissions {list} -- list of permissions to request for eg. ['DEVICE_PRECISE_LOCATION']
+        context {str} -- Text explaining the reason/value for the requested permission
+    """
+
+    def __init__(self, permissions, context=None):
+        super(permission, self).__init__(speech=None)
+        self._messages[:] = []
+        self._response['data']['google']['systemIntent'] = {
+            'intent': 'actions.intent.PERMISSION',
+            'data': {
+                '@type': 'type.googleapis.com/google.actions.v2.PermissionValueSpec',
+                'optContext': context,
+                'permissions': permissions,
+            }
+        }


### PR DESCRIPTION
Permissions support requires API.AI Context support as well as support or Fallback Intents. When permissions are requested, the result of
that request is captured by a Fallback Intent, ideally a Fallback Intent with an In Context.

This PR adds:
- a ```permission``` subclass of _Response for requesting permissions
- support for specifying In Contexts in the intent schema
- support for specifying in intent schema whether or not an intent is of
fallback type