### PR TITLE
Fix missing space when an entity is in the middle of an intent. Fix o…

### DIFF
--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -155,7 +155,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            if re.search(r"\b" + value + r"\b",sub_phrase):
+            if re.search(r"\b" + value + r"\b", sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])
                 self._annotate_params(value)

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -156,15 +156,16 @@ class UserDefinedExample(ExampleBase):
 
         for word in self.text.split():
             if word in self.entity_map:
-                self.data.append({'text': sub_phrase})  # add non-annotated, then deal with annotation
-                sub_phrase = ''
+                if sub_phrase != '':
+                    self.data.append({'text': sub_phrase})  # add non-annotated, then deal with annotation
+                sub_phrase = ' '
                 self.annotate_params(word)
 
             else:
                 sub_phrase += '{} '.format(word)
 
-        if sub_phrase:
-            self.data.append({'text': sub_phrase})
+        if sub_phrase != ' ':
+            self.data.append({'text': sub_phrase.rstrip()})
 
     def annotate_params(self, word):
         """Annotates a given word for the UserSays data field of an Intent object.

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 class Entity():
     """docstring for Entity"""
@@ -147,25 +148,21 @@ class UserDefinedExample(ExampleBase):
         # import ipdb; ipdb.set_trace()
         self.entity_map = entity_map
 
-        self.parse_phrase()
+        self._parse_phrase(self.text)
 
-    def parse_phrase(self):
-        # import ipdb; ipdb.set_trace()
-        annotated = {}
-        sub_phrase = ''
+    def _parse_phrase(self, sub_phrase):
+        if not sub_phrase:
+            return
 
-        for word in self.text.split():
-            if word in self.entity_map:
-                if sub_phrase != '':
-                    self.data.append({'text': sub_phrase})  # add non-annotated, then deal with annotation
-                sub_phrase = ' '
-                self.annotate_params(word)
+        for value in self.entity_map:
+            if re.search(r"\b" + value + r"\b",sub_phrase):
+                parts = sub_phrase.split(value, 1)
+                self._parse_phrase(parts[0])
+                self._annotate_params(value)
+                self._parse_phrase(parts[1])
+                return
 
-            else:
-                sub_phrase += '{} '.format(word)
-
-        if sub_phrase != ' ':
-            self.data.append({'text': sub_phrase.rstrip()})
+        self.data.append({'text': sub_phrase})
 
     def annotate_params(self, word):
         """Annotates a given word for the UserSays data field of an Intent object.


### PR DESCRIPTION
- Fix missing space when an entity is in the middle of an intent.
-- Was resulting in the entity, plus the following word, being concatenated.

- Fix outputing an expression of '' when an entity is the first work in an intent.
-- If the first word in the intent was an entity, then subphrase of '' was written out.

- Fix trailing whitespace at the end of an intent.
-- Whilst it didn't impact anything, there was always a trailing space at the end of every intent, because every word added has a space on the end ('{} '.format(word))