### PR TITLE
Based on the fix submitted by @mutahirqureshi:

### DIFF
--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -155,7 +155,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            re_value = r".\b{}\b".format(value) if value.startswith(("$", "¥", "￥", "€", "£")) else r"\b{}\b".format(value)
+            re_value = r".\b{}\b".format(value) if value.startswith((r'$', r'¥', r'￥', r'€', r'£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import json
 import re
 
@@ -155,7 +157,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            re_value = r".\b{}\b".format(value) if value.startswith((r'$', r'¥', r'￥', r'€', r'£')) else r"\b{}\b".format(value)
+            re_value = r".\b{}\b".format(value[1:]) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -155,7 +155,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '€', '£')) else r"\b{}\b".format(value)
+            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -164,7 +164,7 @@ class UserDefinedExample(ExampleBase):
 
         self.data.append({'text': sub_phrase})
 
-    def annotate_params(self, word):
+    def _annotate_params(self, word):
         """Annotates a given word for the UserSays data field of an Intent object.
 
         Annotations are created using the entity map within the user_says.yaml template.

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -155,7 +155,8 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            if re.search(r"\b" + value + r"\b", sub_phrase):
+            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '€', '£')) else r"\b{}\b".format(value)
+            if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])
                 self._annotate_params(value)

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 class Entity():
     """docstring for Entity"""
@@ -147,24 +148,21 @@ class UserDefinedExample(ExampleBase):
         # import ipdb; ipdb.set_trace()
         self.entity_map = entity_map
 
-        self.parse_phrase()
+        self._parse_phrase(self.text)
 
-    def parse_phrase(self):
-        # import ipdb; ipdb.set_trace()
-        annotated = {}
-        sub_phrase = ''
+    def _parse_phrase(self, sub_phrase):
+        if not sub_phrase:
+            return
 
-        for word in self.text.split():
-            if word in self.entity_map:
-                self.data.append({'text': sub_phrase})  # add non-annotated, then deal with annotation
-                sub_phrase = ''
-                self.annotate_params(word)
+        for value in self.entity_map:
+            if re.search(r"\b" + value + r"\b", sub_phrase):
+                parts = sub_phrase.split(value, 1)
+                self._parse_phrase(parts[0])
+                self._annotate_params(value)
+                self._parse_phrase(parts[1])
+                return
 
-            else:
-                sub_phrase += '{} '.format(word)
-
-        if sub_phrase:
-            self.data.append({'text': sub_phrase})
+        self.data.append({'text': sub_phrase})
 
     def annotate_params(self, word):
         """Annotates a given word for the UserSays data field of an Intent object.

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -155,7 +155,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
+            re_value = r".\b{}\b".format(value) if value.startswith(("$", "¥", "￥", "€", "£")) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])


### PR DESCRIPTION
Fixes handling of annotations which contain spaces
 - The only improvement over mutahirqureshi's code is the use of regex to match against whole words only
 - See comments: https://github.com/treethought/flask-assistant/pull/37
Also innately fixes:
 - missing space when an entity is in the middle of an intent
 - trailing space on the end of all intents