### PR TITLE
Treat entities and synonyms as strings

### DIFF
--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -158,7 +158,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '€', '£')) else r"\b{}\b".format(value)
+            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -158,7 +158,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
+            re_value = r".\b{}\b".format(value) if value.startswith((r'$', r'¥', r'￥', r'€', r'£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -160,11 +160,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map:
-            str_value = str(value) # Treat entities as strings
-            re_value = r".\b{}\b".format(str_value[1:]) \
-                if str_value.startswith(('$', '¥', '￥', '€', '£')) \
-                else r"\b{}\b".format(str_value)
-
+            re_value = r".\b{}\b".format(value[1:]) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import json
 import re
 
@@ -158,7 +160,7 @@ class UserDefinedExample(ExampleBase):
             return
 
         for value in self.entity_map: #TODO python 2.7 compatibility. SyntaxError: Non-ASCII character '\xc2'
-            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
+            re_value = r".\b{}\b".format(value[1:]) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -157,8 +157,8 @@ class UserDefinedExample(ExampleBase):
         if not sub_phrase:
             return
 
-        for value in self.entity_map:
-            re_value = r".\b{}\b".format(value) if value.startswith((r'$', r'¥', r'￥', r'€', r'£')) else r"\b{}\b".format(value)
+        for value in self.entity_map: #TODO python 2.7 compatibility. SyntaxError: Non-ASCII character '\xc2'
+            re_value = r".\b{}\b".format(value) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)
                 self._parse_phrase(parts[0])

--- a/api_ai/models.py
+++ b/api_ai/models.py
@@ -159,7 +159,7 @@ class UserDefinedExample(ExampleBase):
         if not sub_phrase:
             return
 
-        for value in self.entity_map: #TODO python 2.7 compatibility. SyntaxError: Non-ASCII character '\xc2'
+        for value in self.entity_map:
             re_value = r".\b{}\b".format(value[1:]) if value.startswith(('$', '¥', '￥', '€', '£')) else r"\b{}\b".format(value)
             if re.search(re_value, sub_phrase):
                 parts = sub_phrase.split(value, 1)

--- a/api_ai/schema_handlers.py
+++ b/api_ai/schema_handlers.py
@@ -194,9 +194,9 @@ class IntentGenerator(SchemaHandler):
             mapping = {}
             for a in [a for a in annotations if a]:
                 for annotation, entity in a.items():
-                    mapping.update({annotation:entity})
+                    mapping.update({str(annotation):str(entity)})
                     for synonym in self.get_synonyms(annotation, entity):
-                        mapping.update({synonym:entity})
+                        mapping.update({str(synonym):str(entity)})
 
             for phrase in [p for p in phrases if p]:
                 if phrase != '':

--- a/api_ai/schema_handlers.py
+++ b/api_ai/schema_handlers.py
@@ -173,6 +173,15 @@ class IntentGenerator(SchemaHandler):
             params.append(param_info)
         return params
 
+    def get_synonyms(self, annotation, entity):
+        raw_temp = self.entity_yaml()
+        for temp_dict in [d for d in raw_temp if d == entity]:
+            for entry in raw_temp.get(temp_dict):
+                if isinstance(entry, dict):
+                    for a, s in entry.items():
+                        if a == annotation:
+                            for synonym in s:
+                                yield(synonym)
 
     def build_user_says(self, intent):
         raw = self.user_says_yaml()
@@ -181,19 +190,12 @@ class IntentGenerator(SchemaHandler):
         if intent_data:
             phrases = intent_data.get('UserSays', [])
             annotations = intent_data.get('Annotations', [])
-
-            entities = []
-            for d in [d.__dict__ for d in EntityGenerator(self.assist).build_entities()]:
-                entities.append(d)
-
             mapping = {}
             for a in [a for a in annotations if a]:
                 for annotation, entity in a.items():
-                    for d in [d for d in entities if d['name'] == entity]:
-                        for e in [e for e in d['entries'] if e['value'] == annotation]:
-                            mapping.update({annotation:entity})
-                            for synonym in e['synonyms']:
-                                mapping.update({synonym:entity})
+                    mapping.update({annotation:entity})
+                    for synonym in self.get_synonyms(annotation, entity):
+                        mapping.update({synonym:entity})
 
             for phrase in [p for p in phrases if p]:
                 if phrase != '':


### PR DESCRIPTION
Treat entities and synonyms as strings when building entity_map, else regex and string manipulations will fail in models.py if the value provided in usersays.yaml is interpreted as a non-string value.

Issue #55 