### PR TITLE
Fix. Issue #55. Treat entities and synonyms as strings when building entity_map

### DIFF
--- a/api_ai/schema_handlers.py
+++ b/api_ai/schema_handlers.py
@@ -194,9 +194,9 @@ class IntentGenerator(SchemaHandler):
             mapping = {}
             for a in [a for a in annotations if a]:
                 for annotation, entity in a.items():
-                    mapping.update({annotation:entity})
+                    mapping.update({str(annotation):str(entity)})
                     for synonym in self.get_synonyms(annotation, entity):
-                        mapping.update({synonym:entity})
+                        mapping.update({str(synonym):str(entity)})
 
             for phrase in [p for p in phrases if p]:
                 if phrase != '':


### PR DESCRIPTION
Treat entities and synonyms as strings when building entity_map, else regex and string manipulations will fail in models.py if the value provided in usersays.yaml is interpreted as a non-string value.

Issue #55