### PR TITLE
I think '/' is the route not the blueprint

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -105,7 +105,7 @@ In your new webhook.py file:
     from flask_assistant import Assistant, ask, tell
 
     app = Flask(__name__)
-    assist = Assistant(app, '/')
+    assist = Assistant(app, route='/')
 
     
     @assist.action('greeting')


### PR DESCRIPTION
```
def __init__(self, app=None, blueprint=None, route=None):
```