### PR TITLE
Remove unused api attribute of Assistant class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ target/
 # Pycharm
 .idea/
 
+# Virtualenv
+venv/
+
 ###SublimeText###
 
 # cache files for sublime text

--- a/flask_assistant/core.py
+++ b/flask_assistant/core.py
@@ -52,7 +52,7 @@ class Assistant(object):
 
     """
 
-    def __init__(self, app=None, blueprint=None, route=None,dev_token=None,client_token=None):
+    def __init__(self, app=None, blueprint=None, route=None):
 
         self.app = app
         self.blueprint = blueprint
@@ -67,8 +67,6 @@ class Assistant(object):
         self._required_contexts = {}
         self._context_funcs = {}
         self._func_contexts = {}
-
-        self.api = ApiAi(dev_token,client_token)
 
         if route is None and app is not None:
 

--- a/flask_assistant/core.py
+++ b/flask_assistant/core.py
@@ -37,19 +37,18 @@ context_manager = LocalProxy(lambda: find_assistant().context_manager)
 class Assistant(object):
     """Central Interface for interacting with Google Actions via Api.ai.
 
-    The Assitant object routes requests to :func:`action` decorated functions.
+    The Assistant object routes requests to :func:`action` decorated functions.
 
-    The assistant object maps requests recieved from an API.ai agent to Intent-specific view functions.
+    The assistant object maps requests received from an API.ai agent to Intent-specific view functions.
     The view_functions can be properly matched depending on required parameters and contexts.
-    These requests originate from Google Actions and are sent to the Assitant object
-    after through API.ai's infrastrcutre
+    These requests originate from Google Actions and are sent to the Assistant object
+    after through API.ai's infrastructure.
 
 
     Keyword Arguments:
             app {Flask object} -- App instance - created with Flask(__name__) (default: {None})
+            blueprint {Flask Blueprint} -- Flask Blueprint instance to initialize (Default: {None})
             route {str} -- entry point to which initial Alexa Requests are forwarded (default: {None})
-
-
     """
 
     def __init__(self, app=None, blueprint=None, route=None):


### PR DESCRIPTION
The main concern of this PR is this line from the Assistant classes init method:

    self.api = ApiAi(dev_token,client_token)

This `api` attribute is used nowhere in the entire framework, but does produce a warning if the Dialogflow developer access token is not set ([this one](https://github.com/treethought/flask-assistant/blob/3c943dd919382ef68688527b89cb1957242e3270/api_ai/api.py#L25)). This warning is very annoying and since we shouldn't have an unused class attribute anyway I would suggest to remove the attribute.

Also fixes some typos in the class documentation and adds the `venv/` dir to .gitignore.

All tests pass as before.