### PR TITLE
Add access token property to support account linking

### DIFF
--- a/flask_assistant/__init__.py
+++ b/flask_assistant/__init__.py
@@ -10,7 +10,8 @@ from flask_assistant.core import (
     Assistant,
     context_manager,
     intent,
-    request
+    request,
+    access_token
 )
 
 from flask_assistant.response import ask, tell, event, build_item, permission

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,55 @@ import json
 def build_payload(intent, params={}, contexts=[], action='test_action', query='test query'):
 
     return json.dumps({
+        "originalRequest": {
+            "source": "google",
+            "version": "2",
+            "data": {
+                "isInSandbox": False,
+                "surface": {
+                    "capabilities": [
+                        {
+                            "name": "actions.capability.AUDIO_OUTPUT"
+                        },
+                        {
+                            "name": "actions.capability.SCREEN_OUTPUT"
+                        },
+                        {
+                            "name": "actions.capability.MEDIA_RESPONSE_AUDIO"
+                        },
+                        {
+                            "name": "actions.capability.WEB_BROWSER"
+                        }
+                    ]
+                },
+                "inputs": [
+                    {}
+                ],
+                "user": {
+                    "lastSeen": "2018-04-23T15:10:43Z",
+                    "locale": "en-US",
+                    "userId": "abcdefg",
+                    "accessToken": "foobar"
+                },
+                "conversation": {
+                    "conversationId": "123456789",
+                    "type": "ACTIVE",
+                    "conversationToken": "[]"
+                },
+                "availableSurfaces": [
+                    {
+                        "capabilities": [
+                            {
+                                "name": "actions.capability.AUDIO_OUTPUT"
+                            },
+                            {
+                                "name": "actions.capability.SCREEN_OUTPUT"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
         "id": "8ea2d357-10c0-40d1-b1dc-e109cd714f67",
         "timestamp": "2017-06-26T22:43:14.935Z",
         "lang": "en",


### PR DESCRIPTION
Adds the access_token for linked accounts as a property to the Assistant instance, makes it available via a LocalProxy. Updates the test request with 'originalRequest' data. All tests pass.