### PR TITLE
Remove SSML tags from display_text

### DIFF
--- a/docs/source/responses.rst
+++ b/docs/source/responses.rst
@@ -19,6 +19,9 @@ To import the repsonse types:
     from flask_assistant import ask, tell, event, build_item
 
 
+Each response must get a speech text as its first argument and may get a separate text to display on GUI surfaces as a second argument.
+If no display text is given the speech text will be used, but with all SSML tags stripped.
+
 ask
 ---
 

--- a/flask_assistant/response.py
+++ b/flask_assistant/response.py
@@ -324,4 +324,4 @@ def strip_ssml(ssml_string):
         str: The string with all tags (everything between '<' and '>') replaced
             by an empty string.
     """
-    return re.sub(f'<.*?>', '', ssml_string)
+    return re.sub(r'<.*?>', '', ssml_string)

--- a/flask_assistant/response.py
+++ b/flask_assistant/response.py
@@ -1,3 +1,5 @@
+import re
+
 from flask import json, make_response, current_app
 
 
@@ -14,6 +16,11 @@ class _Response(object):
                 "speech": speech
             }
         ]
+
+        # If no display_text given use the speech output,
+        # but strip the SSML tags.
+        if not display_text:
+            display_text = strip_ssml(speech)
 
         self._response = {
             'speech': speech,
@@ -302,3 +309,19 @@ class permission(_Response):
                 'permissions': permissions,
             }
         }
+
+
+def strip_ssml(ssml_string):
+    """Strips all SSML tags from a string.
+
+    Can be used to clean up rendered SSML responses before displaying them to
+    the user.
+
+    Arguments:
+        ssml_string {str} -- A string that may or may not contain SSML tags.
+
+    Returns:
+        str: The string with all tags (everything between '<' and '>') replaced
+            by an empty string.
+    """
+    return re.sub(f'<.*?>', '', ssml_string)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,13 @@
+"""Test the response rendering functionality."""
+
+from flask_assistant.response import strip_ssml
+
+
+def test_ssml_cleanup_necessary():
+    rendered = '<sub alias="foobar">hello world</sub>'
+    assert strip_ssml(rendered) == 'hello world'
+
+
+def test_ssml_cleanup_not_necessary():
+    rendered = 'hello world'
+    assert strip_ssml(rendered) == rendered


### PR DESCRIPTION
Adds a strip_ssml() function to the response module, which can be used to
clean up a rendered speech response with SSML tags before displaying
it to the user in the Google Assistant app.

Changes the default behavior of the display_text attribute of the
_Response class. Currently this defaults to None, which leads Google to
display the 'speech' text on GUI surfaces. This is suboptimal, as that
speech response might contain SSML tags, which are currently shown to the
user. This change sets the display_text explicitly to the same text as
the speech response, but with the SSML tags stripped.

Current users of this class don't have to change anything, they just get
the added benefit of not having to worry about SSML tags.

Also adds two small unittests for the strip_ssml() function.