### PR TITLE
Fix escape bug

### DIFF
--- a/flask_assistant/response.py
+++ b/flask_assistant/response.py
@@ -8,7 +8,7 @@ class _Response(object):
 
     def __init__(self, speech, display_text=None):
 
-        self._speech = escape(speech)
+        self._speech = escape(speech) if speech is not None else speech
         self._integrations = current_app.config.get('INTEGRATIONS', [])
         self._messages = [
             {

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -3,11 +3,12 @@
 These tests use the unittest.mock mechanism to provide a simple Assistant
 instance for the _Response initialization.
 """
-from unittest.mock import patch
-
 from flask import Flask
 from flask_assistant import Assistant
 from flask_assistant.response import _Response
+import pytest
+
+patch = pytest.importorskip('unittest.mock.patch')
 
 
 @patch('flask_assistant.response.current_app')

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,31 @@
+"""Unit test some basic response rendering functionality.
+
+These tests use the unittest.mock mechanism to provide a simple Assistant
+instance for the _Response initialization.
+"""
+from unittest.mock import patch
+
+from flask import Flask
+from flask_assistant import Assistant
+from flask_assistant.response import _Response
+
+
+@patch('flask_assistant.response.current_app')
+def test_response_with_speech(mock):
+    mock = Assistant(Flask(__name__))
+    resp = _Response('foobar')
+    assert resp._response['speech'] == 'foobar'
+
+
+@patch('flask_assistant.response.current_app')
+def test_response_with_None_speech(mock):
+    mock = Assistant(Flask(__name__))
+    resp = _Response(None)
+    assert resp._response['speech'] is None
+
+
+@patch('flask_assistant.response.current_app')
+def test_response_speech_escaping(mock):
+    mock = Assistant(Flask(__name__))
+    resp = _Response('foo & bar')
+    assert resp._response['speech'] == 'foo &amp; bar'


### PR DESCRIPTION
The speech escaping did unfortunately introduce a bug because the [`xml.sax.saxutils.escape`](https://github.com/python/cpython/blob/ef347535f289baad22c0601e12a36b2dcd155c3a/Lib/xml/sax/saxutils.py#L18) function uses `str.replace` under the hood and thus throws an error when the string to escape is None, as it is by default in several of the `_Response` subclasses. This checks the string first.

Also adds some basic unittests for the `_Response` class to prevent this from happening again.

My apologies for the confusion.