### PR TITLE
Fix KeyError on access_token

### DIFF
--- a/flask_assistant/core.py
+++ b/flask_assistant/core.py
@@ -286,8 +286,9 @@ class Assistant(object):
         self.context_in = self.request['result'].get('contexts', [])
 
         # Get access token from request
-        user_obj = self.request['originalRequest']['data']['user']
-        self.access_token = user_obj.get('accessToken')
+        original_request = self.request.get('originalRequest')
+        if original_request:
+            self.access_token = original_request['data']['user'].get('accessToken')
 
         self._update_contexts()
 


### PR DESCRIPTION
The 'originalRequest' object contains data send from Actions on Google
to Dialogflow. It is not present when the fulfillment is invoked via
Dialogflows web UI directly, thus raising a KeyError. This adds an
additional check for the presence of that object.

Note that according to the documentation the 'data' and 'user' objects
can never raise KeyErrors as they are always present in the
'originalRequest' object (https://developers.google.com/actions/dialogflow/webhook).