### PR TITLE
Fixing Errors for no Image URL in the List View. Google Actions retur…

### DIFF
--- a/flask_assistant/response.py
+++ b/flask_assistant/response.py
@@ -206,11 +206,12 @@ def build_item(
         "info": {"key": key or title, "synonyms": synonyms or []},
         "title": title,
         "description": description,
-        "image": {
-            "imageUri": img_url or "",
-            "accessibilityText": alt_text or "{} img".format(title),
-        },
     }
+
+    if img_url:
+            img_payload = {"imageUri": img_url, "accessibilityText": alt_text or "{} img".format(title)}
+            item["image"] = img_payload
+
     return item
 
 


### PR DESCRIPTION
Google Actions simulator returns errors when there is no image URL in the List View. For example in Placer County Chat it lists four FAQs but these errors show up in the Errors tab. 
![image](https://user-images.githubusercontent.com/10067761/60051270-7a698d80-9687-11e9-8f4a-7dad9fdccc6d.png)

