### PR TITLE
Allow usage of service fabric like others flask components

### DIFF
--- a/flask_assistant/core.py
+++ b/flask_assistant/core.py
@@ -100,20 +100,10 @@ class Assistant(object):
 
         self.api = ApiAi(dev_token, client_token)
 
-        if route is None and app is not None:
-            self._route = "/"
-
         if app is not None:
             self.init_app(app)
         elif blueprint is not None:
             self.init_blueprint(blueprint)
-        else:
-            raise ValueError(
-                "Assistant object must be intialized with either an app or blueprint"
-            )
-
-        if self.client_id is None:
-            self.client_id = self.app.config.get("AOG_CLIENT_ID")
 
         if project_id is None:
             import warnings
@@ -126,14 +116,18 @@ class Assistant(object):
             )
 
     def init_app(self, app):
+        self.app = app
 
         if self._route is None:
-            raise TypeError("route is a required argument when app is not None")
+            self._route = "/"
 
         app.assist = self
         app.add_url_rule(
             self._route, view_func=self._flask_assitant_view_func, methods=["POST"]
         )
+        if self.client_id is None:
+            self.client_id = self.app.config.get("AOG_CLIENT_ID")
+
 
     # Taken from Flask-ask courtesy of @voutilad
     def init_blueprint(self, blueprint, path="templates.yaml"):
@@ -161,6 +155,9 @@ class Assistant(object):
             "", view_func=self._flask_assitant_view_func, methods=["POST"]
         )
         # blueprint.jinja_loader = ChoiceLoader([YamlLoader(blueprint, path)])
+        if self.client_id is None:
+            self.client_id = self.app.config.get("AOG_CLIENT_ID")
+
 
     @property
     def request(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ flask==1.0.2
 google-auth==1.6.3
 idna==2.8
 itsdangerous==1.1.0
-jinja2==2.10
+jinja2==2.10.1
 markupsafe==1.1.0
 pyasn1-modules==0.2.7
 pyasn1==0.4.7
@@ -15,5 +15,5 @@ requests==2.21.0
 rsa==4.0
 ruamel.yaml==0.15.81
 six==1.12.0
-urllib3==1.24.2
+urllib3==1.24.3
 werkzeug==0.15.3


### PR DESCRIPTION
Hi,
Would be great if flask_assistant can support application fabric if not using blueprint for sure :)

extensions.py:
```
from flask_assistant import Assistant

assist = Assistant(project_id='xxx')
```

app.py:
```
from extensions import assist

assist.init_app(app)
```