### PR TITLE
Use dialogflow types from 'google-cloud-dialogflow' package

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,7 @@ MarkupSafe = "*"
 "ruamel.yaml" = "*"
 Werkzeug = "*"
 google-auth = "*"
-dialogflow = "*"
+google-cloud-dialogflow = "*"
 
 [requires]
 python_version = "3.7"

--- a/flask_assistant/response/dialogflow.py
+++ b/flask_assistant/response/dialogflow.py
@@ -1,4 +1,4 @@
-import dialogflow_v2beta1 as df
+from google.cloud import dialogflow_v2 as df
 from google.protobuf.json_format import MessageToDict
 
 
@@ -6,12 +6,12 @@ def build_card(
     text, title, img_url=None, img_alt=None, subtitle=None, link=None, link_title=None,
 ):
 
-    button = df.types.intent_pb2.Intent.Message.Card.Button(
+    button = df.Intent.Message.Card.Button(
         text=link_title, postback=link
     )
-    card = df.types.intent_pb2.Intent.Message.Card(title=title, subtitle=text)
+    card = df.Intent.Message.Card(title=title, subtitle=text)
     card.buttons.append(button)
-    payload = MessageToDict(card)
+    payload = df.Intent.Message.Card.to_dict(card)
     return {"card": payload, "lang": "en"}
     # card_payload = {"card": {"title": title, "subtitle": text, "formattedText": text}}
     # return card_payload

--- a/flask_assistant/response/hangouts.py
+++ b/flask_assistant/response/hangouts.py
@@ -1,5 +1,4 @@
-import dialogflow_v2beta1 as df
-from google.protobuf.json_format import MessageToDict
+from google.cloud import dialogflow_v2 as df
 import logging
 
 
@@ -15,11 +14,11 @@ def build_card(
     if link_title is None:
         link_title = "Learn More"
 
-    button = df.types.intent_pb2.Intent.Message.Card.Button(
+    button = df.Intent.Message.Card.Button(
         text=link_title, postback=link
     )
-    card = df.types.intent_pb2.Intent.Message.Card(title=title, subtitle=text)
+    card = df.Intent.Message.Card(title=title, subtitle=text)
     card.buttons.append(button)
 
-    payload = MessageToDict(card)
+    payload = df.Intent.Message.Card.to_dict(card)
     return {"card": payload, "platform": "GOOGLE_HANGOUTS", "lang": "en"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ cachetools==4.2.0
 certifi==2020.12.5
 chardet==4.0.0
 click==8.0.0a1
-dialogflow==1.1.0
+google-cloud-dialogflow==2.9.1
 flask==1.1.2
-google-api-core[grpc]==1.24.1
-google-auth==1.24.0
+google-api-core[grpc]==1.28.0
+google-auth==1.25.0
 googleapis-common-protos==1.52.0
 grpcio==1.34.0
 idna==2.10

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "ruamel.yaml",
         "aniso8601",
         "google-auth",
-        "dialogflow",
+        "google-cloud-dialogflow",
     ],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],


### PR DESCRIPTION
Hello,

I'm one of the maintainers of https://github.com/googleapis/python-dialogflow. I noticed your package was using the previous package name [`dialogflow`](https://pypi.org/project/dialogflow/) which we are no longer updating.

This PR migrates the code in this repository to use the types from the latest release of [`google-cloud-dialogflow`](https://pypi.org/project/google-cloud-dialogflow/) instead.

Notable changes:
- Import is `from google.cloud import dialogflow` rather than `import dialogflow`
- Types are [proto-plus](https://proto-plus-python.readthedocs.io/en/stable/)

A longer description of changes from `dialogflow` -> `google-cloud-dialogflow` is available [here](https://github.com/googleapis/python-dialogflow/blob/main/UPGRADING.md#enums-and-types).

Thank you!